### PR TITLE
Use semantic version constraint ^9.13 for m4tthumphrey/php-gitlab-api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/contracts": "^5.5|^6.0",
         "illuminate/support": "^5.5|^6.0",
         "graham-campbell/manager": "^4.2",
-        "m4tthumphrey/php-gitlab-api": "9.13.*",
+        "m4tthumphrey/php-gitlab-api": "^9.13",
         "php-http/client-common": "^1.9",
         "php-http/cache-plugin": "^1.6",
         "symfony/cache": "^3.3|^4.0"


### PR DESCRIPTION
That enables usage of release 9.14.0 https://github.com/m4tthumphrey/php-gitlab-api/releases/tag/9.14.0

It allows passing arbitrary additional options to MergeRequests#create()