### PR TITLE
Remove `$` from copiable bash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Laravel GitLab requires [PHP](https://php.net) 7.2-8.0. This particular version 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org). You will need to install any packages that "provide" `psr/http-client-implementation` and `psr/http-factory-implementation`. Most users will want:
 
 ```bash
-$ composer require "graham-campbell/gitlab:^5.4" "guzzlehttp/guzzle:^7.2" "http-interop/http-factory-guzzle:^1.0"
+composer require "graham-campbell/gitlab:^5.4" "guzzlehttp/guzzle:^7.2" "http-interop/http-factory-guzzle:^1.0"
 ```
 
 Once installed, if you are not using automatic package discovery, then you need to register the `GrahamCampbell\GitLab\GitLabServiceProvider` service provider in your `config/app.php`.
@@ -52,7 +52,7 @@ Laravel GitLab requires connection configuration.
 To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+php artisan vendor:publish
 ```
 
 This will create a `config/gitlab.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
The New Github markdown renderer allows code sections to be copied with a single click. For the moment, it's also copied pseudo *$* for indicating it's in the shell. 