### PR TITLE
Simplify ResultPager instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ class Foo
 app(Foo::class)->bar();
 ```
 
+When the amount of items you receive is not sufficient, you may use the `Gitlab\ResultPager` like so:
+
+```php
+$pager = GitLab::resultPager();
+$issues = $pager->fetchAll($client->issues(), 'all', [null, ['state' => 'closed']]);
+```
+
 For more information on how to use the `Gitlab\Client` class we are calling behind the scenes here, check out the docs at https://github.com/GitLabPHP/Client/tree/11.13.0#general-api-usage, and the manager class at https://github.com/GrahamCampbell/Laravel-Manager#usage.
 
 ##### Further Information

--- a/src/GitLabManager.php
+++ b/src/GitLabManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace GrahamCampbell\GitLab;
 
 use Gitlab\Client;
+use Gitlab\ResultPager;
 use GrahamCampbell\Manager\AbstractManager;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\Arr;
@@ -84,6 +85,18 @@ class GitLabManager extends AbstractManager
     {
         parent::__construct($config);
         $this->factory = $factory;
+    }
+
+    /**
+     * Instantiate a result pager.
+     *
+     * @param string|null $connectionName
+     *
+     * @return \Gitlab\ResultPager
+     */
+    public function resultPager(?string $connectionName = null): ResultPager
+    {
+        return new ResultPager($this->connection($connectionName));
     }
 
     /**


### PR DESCRIPTION
This simplifies the usage as follows

```diff
$manager = app(GitLabManager::class);
-$pager = new ResultPager($manager->connection());
+$pager = $manager->resultPager();
```

More importantly, it improves discoverability.
Method completion on `GitLabManager` now provides access to the `ResultPager`.