### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,20 +12,26 @@ jobs:
     strategy:
       matrix:
         php: ['7.4', '8.0', '8.1', '8.2', '8.3']
-        laravel: ['8', '9', '10']
+        laravel: ['8', '9', '10', '11']
         exclude:
           - php: '7.4'
             laravel: '9'
           - php: '7.4'
             laravel: '10'
+          - php: '7.4'
+            laravel: '11'
           - php: '8.0'
             laravel: '10'
+          - php: '8.0'
+            laravel: '11'
           - php: '8.2'
             laravel: '8'
           - php: '8.3'
             laravel: '8'
           - php: '8.3'
             laravel: '9'
+          - php: '8.1'
+            laravel: '11'
 
     steps:
       - name: Checkout Code
@@ -66,6 +72,14 @@ jobs:
           max_attempts: 5
           command: composer require "laravel/framework:^10.34.2" "phpunit/phpunit:^10.4.2" --no-update --no-interaction
         if: "matrix.laravel == '10'"
+
+      - name: Select Laravel 11
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require "laravel/framework:^11.0" "phpunit/phpunit:^10.4.2" --no-update --no-interaction
+        if: "matrix.laravel == '11'"
 
       - name: Install PHP Dependencies
         uses: nick-invision/retry@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 phpunit.xml
 vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Laravel GitLab was created by, and is maintained by [Graham Campbell](https://gi
 
 ## Installation
 
-This version requires [PHP](https://www.php.net/) 7.4-8.3 and supports [Laravel](https://laravel.com/) 8-10.
+This version requires [PHP](https://www.php.net/) 7.4-8.3 and supports [Laravel](https://laravel.com/) 8-11.
 
 | GitLab | L5.5               | L5.6               | L5.7               | L5.8               | L6                 | L7                 | L8                 | L9                 | L10                | L11                |
 |--------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ This version requires [PHP](https://www.php.net/) 7.4-8.3 and supports [Laravel]
 | 5.6    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | 6.0    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | 7.4    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| 8.0    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: |
+| 7.5    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org/):
 
 ```bash
-$ composer require "graham-campbell/gitlab:^8.0"
+$ composer require "graham-campbell/gitlab:^7.5"
 ```
 
 Once installed, if you are not using automatic package discovery, then you need to register the `GrahamCampbell\GitLab\GitLabServiceProvider` service provider in your `config/app.php`.

--- a/README.md
+++ b/README.md
@@ -18,20 +18,21 @@ Laravel GitLab was created by, and is maintained by [Graham Campbell](https://gi
 
 This version requires [PHP](https://www.php.net/) 7.4-8.3 and supports [Laravel](https://laravel.com/) 8-10.
 
-| GitLab | L5.5               | L5.6               | L5.7               | L5.8               | L6                 | L7                 | L8                 | L9                 | L10                |
-|--------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
-| 1.10   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                |
-| 2.7    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
-| 3.3    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
-| 4.4    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
-| 5.6    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
-| 6.0    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| 7.4    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| GitLab | L5.5               | L5.6               | L5.7               | L5.8               | L6                 | L7                 | L8                 | L9                 | L10                | L11                |
+|--------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| 1.10   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                |
+| 2.7    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                | :x:                |
+| 3.3    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
+| 4.4    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                |
+| 5.6    | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| 6.0    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| 7.4    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| 8.0    | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: |
 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org/):
 
 ```bash
-$ composer require "graham-campbell/gitlab:^7.4"
+$ composer require "graham-campbell/gitlab:^8.0"
 ```
 
 Once installed, if you are not using automatic package discovery, then you need to register the `GrahamCampbell\GitLab\GitLabServiceProvider` service provider in your `config/app.php`.

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "graham-campbell/manager": "^5.1",
         "guzzlehttp/guzzle": "^7.8.1",
         "guzzlehttp/psr7": "^2.6.2",
-        "illuminate/contracts": "^8.75 || ^9.0 || ^10.0",
-        "illuminate/support": "^8.75 || ^9.0 || ^10.0",
+        "illuminate/contracts": "^8.75 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/support": "^8.75 || ^9.0 || ^10.0 || ^11.0",
         "m4tthumphrey/php-gitlab-api": "11.13.*",
         "symfony/cache": "^5.4 || ^6.0"
     },


### PR DESCRIPTION
This pull request adds support for Laravel 11. It must be a major release for `8.0`.


Also, I think we should remove the old version of Laravel and PHP. What do you think? If you agree, I can create a new pull request for this changes.

(closes #47)