### PR TITLE
Require m4tthumphrey/php-gitlab-api 11.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "guzzlehttp/psr7": "^2.6.2",
         "illuminate/contracts": "^8.75 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/support": "^8.75 || ^9.0 || ^10.0 || ^11.0",
-        "m4tthumphrey/php-gitlab-api": "11.13.*",
+        "m4tthumphrey/php-gitlab-api": "11.14.*",
         "symfony/cache": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
The changelog for [v7.5.0](https://github.com/GrahamCampbell/Laravel-GitLab/releases/tag/v7.5.0) mentions requiring m4tthumphrey/php-gitlab-api 11.14, but the composer.json was never updated to match.

Fixes #49